### PR TITLE
Use git hashes to determine which docs to rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+hashstash

--- a/GenerateDocumentation.sh
+++ b/GenerateDocumentation.sh
@@ -1,5 +1,26 @@
 #!/bin/bash
 
+run_jazzy () {
+  VERSION=$(git describe --tags | cut -d - -f -1)
+  tput setab 7
+  tput setaf 0
+  echo "~ $i: $VERSION ~"
+  tput sgr0
+
+  jazzy \
+    --clean \
+    --author James Bean \
+    --author_url http://jamesbean.info \
+    --github_url https://github.com/dn-m/$i \
+    --module-version $VERSION \
+    --module $i \
+    --root-url https://dn-m.github.io \
+    --output $SITE_DIR/$i \
+    --skip-undocumented \
+    --hide-documentation-coverage \
+    --theme $SITE_DIR/dependencies/bean
+}
+
 WORK_DIR=${PWD}
 if [ $2 ]; then
   SITE_DIR=$2
@@ -19,25 +40,8 @@ for i in $( ls ); do
 
       cd $i
 
-      VERSION=$(git describe --tags | cut -d - -f -1)
 
-      tput setab 7
-      tput setaf 0
-      echo "~ $i: $VERSION ~"
-      tput sgr0    # reset everything before exiting
-
-      jazzy \
-        --clean \
-        --author James Bean \
-        --author_url http://jamesbean.info \
-        --github_url https://github.com/dn-m/$i \
-        --module-version $VERSION \
-        --module $i \
-        --root-url https://dn-m.github.io \
-        --output $SITE_DIR/$i \
-        --skip-undocumented \
-        --hide-documentation-coverage \
-        --theme $SITE_DIR/dependencies/bean
+        run_jazzy
 
       cd ../
 

--- a/GenerateDocumentation.sh
+++ b/GenerateDocumentation.sh
@@ -51,6 +51,8 @@ fi
 
 cd $FRAMEWORKS_DIR
 
+newindex=0
+NEWHASHES=()
 for i in $( ls ); do
   if [[ -d $i ]]; then
 
@@ -86,6 +88,12 @@ for i in $( ls ); do
         # There is no hashstash file
         run_jazzy
       fi
+
+      # Save new hash value for stashing
+      printf -v "$i" %s $HASH
+      # Create an array of all stashed hash keys
+      NEWHASHES[$newindex]="$i"
+      ((newindex++)) # increment index
 
       cd ../
 

--- a/GenerateDocumentation.sh
+++ b/GenerateDocumentation.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
 
-run_jazzy () {
-  VERSION=$(git describe --tags | cut -d - -f -1)
-  tput setab 7
-  tput setaf 0
-  echo "~ $i: $VERSION ~"
-  tput sgr0
+print_color () { tput setab 7; tput setaf 0; echo "$1"; tput sgr0; }
 
+run_jazzy () {
   jazzy \
     --clean \
     --author James Bean \
@@ -40,7 +36,10 @@ for i in $( ls ); do
 
       cd $i
 
+      print_color "~~~ $i ~~~"
 
+      VERSION=$(git describe --tags | cut -d - -f -1)
+      print_color "Version: $VERSION"
         run_jazzy
 
       cd ../

--- a/GenerateDocumentation.sh
+++ b/GenerateDocumentation.sh
@@ -29,6 +29,26 @@ else
   FRAMEWORKS_DIR="../Frameworks"
 fi
 
+# Make hashstash accessible in environment
+hasStash=0
+stashprefix="HASHSTASH__"
+stashindex=0
+STASHEDHASHES=()
+if [[ -f "hashstash" ]]; then
+  hasStash=1
+  # Read hashstash line by line
+  while IFS="=" read -r -a array; do
+    ((${#array[@]} >= 1)) || continue # ignore blank lines
+    # Store each key as a prefixed (HASHSTASH__) variable
+    printf -v "$stashprefix${array[@]:0:1}" %s ${array[@]:1}
+    # Create an array of all stashed hashes
+    STASHEDHASHES[$stashindex]="$stashprefix${array[@]:0:1}"
+    ((stashindex++)) # increment index
+  done < hashstash # <-- defines which file is read in
+  # At this point we have a series of variables in the form
+  # `HASHSTASH__ModuleName` and an array `STASHEDHASHES` of those variable names
+fi
+
 cd $FRAMEWORKS_DIR
 
 for i in $( ls ); do

--- a/GenerateDocumentation.sh
+++ b/GenerateDocumentation.sh
@@ -102,6 +102,16 @@ done
 
 cd $SITE_DIR
 
+# Clean old hashstash
+if [[ -f "hashstash" ]]; then
+  rm hashstash
+fi
+# Write new hashes to hashstash
+for i in "${NEWHASHES[@]}"
+do
+  echo "$i=${!i}" >> hashstash
+done
+
 # Clean and build assets for main index
 for i in $( ls ); do
   if [[ -d $i ]]; then

--- a/GenerateDocumentation.sh
+++ b/GenerateDocumentation.sh
@@ -59,13 +59,33 @@ for i in $( ls ); do
       print_color "~~~ $i ~~~"
 
       VERSION=$(git describe --tags | cut -d - -f -1)
+      HASHKEY=$stashprefix$i
+      HASH=$(git log -n 1 --pretty=format:"%H")
 
       if [[ -n $VERSION ]]; then
         print_color "Version: $VERSION"
       else
         print_color "Version: undefined"
       fi
+
+      if [[ $hasStash == 1 ]]; then
+        if [ -n "${!HASHKEY}" ]; then
+          # A hash has been stashed for this module, check for matches
+          if [[ $HASH = ${!HASHKEY} ]]; then
+            # The current hash and the stashed hash match
+            print_color "$i has not changed, skipping..."
+          else
+            # The current hash and the stashed hash don’t match, proceed
+            run_jazzy
+          fi
+        else
+          # There is no stashed hash, proceed
+          run_jazzy
+        fi
+      else
+        # There is no hashstash file
         run_jazzy
+      fi
 
       cd ../
 

--- a/GenerateDocumentation.sh
+++ b/GenerateDocumentation.sh
@@ -39,7 +39,12 @@ for i in $( ls ); do
       print_color "~~~ $i ~~~"
 
       VERSION=$(git describe --tags | cut -d - -f -1)
-      print_color "Version: $VERSION"
+
+      if [[ -n $VERSION ]]; then
+        print_color "Version: $VERSION"
+      else
+        print_color "Version: undefined"
+      fi
         run_jazzy
 
       cd ../


### PR DESCRIPTION
On jazzy build stores current hashes in `hashstash`.
If `hashstash` exists, checks current hashes against stashed hashes and only builds if they are non-matching.

Closes #7 
#### Still to-do

Create optional flag to `./GenerateDocumentation.sh` to ignore existing `hashstash`. In the meantime, deleting `hashstash` will allow a clean rebuild.
