### PR TITLE
Inject module dependencies into Jazzy-generated docs

### DIFF
--- a/GenerateDocumentation.sh
+++ b/GenerateDocumentation.sh
@@ -132,3 +132,17 @@ done
 
 # Generate main index
 ./GenerateFrontpage.sh
+
+# Modify jazzy output to inject dependencies into navbar
+for i in $( ls ); do
+  if [[ -d $i ]]; then
+    if ! [ $i = dependencies -o $i = build ]; then
+      if [[ -e "$i/dependencies.json" ]]; then
+        print_color "Adding dependencies to menus in $i..."
+        for html in $( find $i -name '*.html' ); do
+          ruby InjectDependencies.rb "$html" "$i/dependencies.json"
+        done
+      fi
+    fi
+  fi
+done

--- a/GenerateDocumentation.sh
+++ b/GenerateDocumentation.sh
@@ -15,6 +15,8 @@ build_docs () {
     --skip-undocumented \
     --hide-documentation-coverage \
     --theme $SITE_DIR/dependencies/bean
+
+  . $SITE_DIR/HandleDependencies.sh $i $SITE_DIR
 }
 
 WORK_DIR=${PWD}

--- a/GenerateDocumentation.sh
+++ b/GenerateDocumentation.sh
@@ -2,7 +2,7 @@
 
 print_color () { tput setab 7; tput setaf 0; echo "$1"; tput sgr0; }
 
-run_jazzy () {
+build_docs () {
   jazzy \
     --clean \
     --author James Bean \
@@ -78,15 +78,15 @@ for i in $( ls ); do
             print_color "$i has not changed, skipping..."
           else
             # The current hash and the stashed hash don’t match, proceed
-            run_jazzy
+            build_docs
           fi
         else
           # There is no stashed hash, proceed
-          run_jazzy
+          build_docs
         fi
       else
         # There is no hashstash file
-        run_jazzy
+        build_docs
       fi
 
       # Save new hash value for stashing

--- a/HandleDependencies.sh
+++ b/HandleDependencies.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+i=$1
+SITE_DIR=$2
+
+IMPORT_FROM="Cartfile"
+EXPORT_TO="$SITE_DIR/$i/dependencies.json"
+
+if [[ -f $IMPORT_FROM ]]; then
+  # Count lines in Cartfile for later reference
+  lastline=`<$IMPORT_FROM grep -c '[^[:space:]]'`
+  count=1 # Initialise counter token
+  # Write opening line of dependencies.json
+  echo "{\"dependencies\":[" > $EXPORT_TO
+  # Read Cartfile line by line
+  while IFS= read -r -a array; do
+    ((${#array[@]} >= 1)) || continue # ignore blank lines
+    echo "${array[@]}"
+    # Test line is in format: registry "org/repo"[ => version]
+    # where version information is optional for matching
+    if [[ ${array[@]} =~ ^(.+)[[:space:]]\"(.+)/(.+)\"[[:space:]]*(.+)*$ ]]
+    then
+      # Use regex groups to parse out parts of dependency declaration
+      REGISTRY=${BASH_REMATCH[1]}
+      ORGANISATION=${BASH_REMATCH[2]}
+      REPO=${BASH_REMATCH[3]}
+      VERSION=${BASH_REMATCH[4]}
+      properties=(REGISTRY ORGANISATION REPO VERSION)
+      pos=$(( ${#properties[*]} - 1 ))
+      last=${properties[$pos]} # get length for later reference
+      # Properties of a single dependency start writing here ===================
+      echo "{" >> $EXPORT_TO
+      for i in "${properties[@]}"; do
+        key=`echo $i | tr '[:upper:]' '[:lower:]'`
+        if [[ $i == $last ]]; then
+          echo "\"$key\": \"${!i}\"" >> $EXPORT_TO
+        else
+          echo "\"$key\": \"${!i}\"," >> $EXPORT_TO
+        fi
+      done
+      if [[ $count -eq $lastline ]]; then
+        echo "}" >> $EXPORT_TO # omit separating comma for last block
+      else
+        echo "}," >> $EXPORT_TO
+      fi
+      # Properties of a single dependency end writing here =====================
+      ((count++))
+      echo $count
+    fi
+  done < $IMPORT_FROM # <-- defines which file is read in
+  echo "]}" >> $EXPORT_TO # close dependencies.json
+fi

--- a/HandleDependencies.sh
+++ b/HandleDependencies.sh
@@ -15,7 +15,6 @@ if [[ -f $IMPORT_FROM ]]; then
   # Read Cartfile line by line
   while IFS= read -r -a array; do
     ((${#array[@]} >= 1)) || continue # ignore blank lines
-    echo "${array[@]}"
     # Test line is in format: registry "org/repo"[ => version]
     # where version information is optional for matching
     if [[ ${array[@]} =~ ^(.+)[[:space:]]\"(.+)/(.+)\"[[:space:]]*(.+)*$ ]]
@@ -45,7 +44,6 @@ if [[ -f $IMPORT_FROM ]]; then
       fi
       # Properties of a single dependency end writing here =====================
       ((count++))
-      echo $count
     fi
   done < $IMPORT_FROM # <-- defines which file is read in
   echo "]}" >> $EXPORT_TO # close dependencies.json

--- a/InjectDependencies.rb
+++ b/InjectDependencies.rb
@@ -1,0 +1,50 @@
+require 'rubygems'
+require 'nokogiri'
+require 'json'
+# set file to modify from first argument if present
+if ARGV[0].nil?
+  html_to_mod = 'index.html'
+else
+  html_to_mod=ARGV[0]
+end
+# set json to parse from second argument if present
+if ARGV[1].nil?
+  json_to_read = 'dependencies.json'
+else
+  json_to_read=ARGV[1]
+end
+# make sure the files we’re asking for exist before doing anything
+if (File.exist?(json_to_read)) && (File.exist?(html_to_mod))
+  html = File.read(html_to_mod)
+  json = File.read(json_to_read)
+  dependencies_hash = JSON.parse(json)
+
+  page = Nokogiri::HTML(html)
+  # clean out an existing #dependencies node if it exists
+  if page.css("#dependencies")
+    page.css("#dependencies").remove
+  end
+  # create new #dependencies navigation section
+  page.css(".nav-groups")[0].add_child '<li class="nav-group-name" id="dependencies">
+              <span class="nav-group-name-link">Dependencies</span>
+              <ul class="nav-group-tasks"></ul>
+            </li>'
+  dependencies_hash["dependencies"].each do |dependency|
+    if dependency["organisation"] == "dn-m"
+      dependency_link="/"+dependency["repo"]+"/index.html"
+    elsif dependency["registry"] == "github"
+      dependency_link="https://github.com/"+dependency["organisation"]+"/"+dependency["repo"]
+    end
+    if dependency_link.nil?
+      item_html = '<li class="nav-group-task"><span class="nav-group-task-link">'+dependency["repo"]+'</span></li>'
+    else
+      item_html = '<li class="nav-group-task">
+        <a class="nav-group-task-link" href="'+dependency_link+'">'+dependency["repo"]+'</a>
+      </li>'
+    end
+    page.css("#dependencies .nav-group-tasks")[0].add_child item_html
+  end
+  File.write(html_to_mod, page.to_html)
+else
+  puts 'Error: looks like your arguments don’t match real life files.'
+end

--- a/InjectDependencies.rb
+++ b/InjectDependencies.rb
@@ -36,11 +36,15 @@ if (File.exist?(json_to_read)) && (File.exist?(html_to_mod))
       dependency_link="https://github.com/"+dependency["organisation"]+"/"+dependency["repo"]
     end
     if dependency_link.nil?
-      item_html = '<li class="nav-group-task"><span class="nav-group-task-link">'+dependency["repo"]+'</span></li>'
+      item_html = '<li class="nav-group-task"><span class="nav-group-task-link">'+dependency["repo"]+'</span>'
     else
       item_html = '<li class="nav-group-task">
-        <a class="nav-group-task-link" href="'+dependency_link+'">'+dependency["repo"]+'</a>
-      </li>'
+        <a class="nav-group-task-link" href="'+dependency_link+'">'+dependency["repo"]+'</a>'
+    end
+    if dependency["version"].to_s.strip.length == 0
+      item_html = item_html+'</li>'
+    else
+      item_html = item_html+' <span class="dependency-version">'+dependency["version"]+'</span></li>'
     end
     page.css("#dependencies .nav-group-tasks")[0].add_child item_html
   end


### PR DESCRIPTION
So, it turns out [Nokogiri](http://www.nokogiri.org/) and Ruby are not _that_ complicated. Closes #11 
##### This pull request implements
1. Parsing of each module’s `Cartfile` to a `dependencies.json` in the relevant site directory.
2. Processing of `dependencies.json` into HTML, which is injected into Jazzy’s generated HTML files using Nokogiri in `InjectDependencies.rb`.
3. Extension to `GenerateDocumentation.sh` to iterate through all HTML files and process them with `InjectDependencies.rb`, passing in the appropriate paths.
##### To get this working you will need to [install Nokogiri](http://www.nokogiri.org/tutorials/installing_nokogiri.html#mac_os_x)

``` sh
gem install nokogiri
```
##### A note on implementation

The `Cartfile` parser assumes dependencies in the format

``` sh
# registry "organisation/repo" [version-glob]
github "dn-m/TreeTools" ~> 0.3
github "dn-m/ArrayTools"
github "SwiftyJSON/SwiftyJSON"
```

These are converted to a JSON object:

``` json
{
  "registry": "github",
  "organisation": "dn-m",
  "repo": "TreeTools",
  "version": "~> 0.3"
}
```

If no version glob is present, the value for `version` will be empty.

`InjectDependencies.rb` processes each dependency according to the following tests:
1. If `organisation` is `dn-m`, assume docs exist, print `repo` linked to `/repo/index.html`
2. Else if `registry` is `github`, print `repo` with synthesised link: `https://github.com/organisation/repo`
3. Else print `repo` without linking

In all cases, `InjectDependencies.rb` checks `version` and if it is not empty prints the version glob following the linked `repo` name. Version globs are wrapped in a span of class `dependency-version` in case you want to add a line to `dependencies/bean/assets/css/jazzy.css.scss` to style them.
